### PR TITLE
Create the GeoIP directories if needed

### DIFF
--- a/geoip2_state.go
+++ b/geoip2_state.go
@@ -308,7 +308,7 @@ func mkdirIfMissing(path string) error {
 		return nil
 	}
 
-	return os.MkdirAll(path, 0o600)
+	return os.MkdirAll(path, 0o700)
 }
 
 var (

--- a/geoip2_state.go
+++ b/geoip2_state.go
@@ -91,6 +91,9 @@ func (g *GeoIP2State) CaddyModule() caddy.ModuleInfo {
 // Start implements caddy.App.
 func (g *GeoIP2State) Start() error {
 	caddy.Log().Named(moduleName).Debug("start")
+	if err := g.ensureDirectories(); err != nil {
+		return err
+	}
 	go g.loadGeoIPReaders()
 	go g.runGeoIPUpdate()
 	return nil
@@ -281,6 +284,31 @@ func (g *GeoIP2State) runGeoIPUpdate() {
 			}
 		}
 	}
+}
+
+func (g *GeoIP2State) ensureDirectories() error {
+	// Create the database directory if needed
+	if err := mkdirIfMissing(g.DatabaseDirectory); err != nil {
+		return fmt.Errorf("ensuring database directory %q: %w", g.DatabaseDirectory, err)
+	}
+
+	// Create the lock file directory if needed
+	lockFileDir := filepath.Dir(g.LockFile)
+
+	if err := mkdirIfMissing(lockFileDir); err != nil {
+		return fmt.Errorf("ensuring lock file directory %q: %w", lockFileDir, err)
+	}
+
+	return nil
+}
+
+func mkdirIfMissing(path string) error {
+	if path == "" {
+		// If the folder path is empty, we can't create it
+		return nil
+	}
+
+	return os.MkdirAll(path, 0o600)
 }
 
 var (


### PR DESCRIPTION
If the DatabaseDirectory or the folder containing the LockFile does not exist, then this will happen:

```
caddy-1 |{"level":"error","ts":1775559071.0254245,"logger":"geoip2","msg":"missing geoip database file","editionID":"GeoLite2-City"}
caddy-1 |{"level":"error","ts":1775559071.0255172,"logger":"geoip2","msg":"creating database writer","editionID":"GeoLite2-City","error":"database directory is not available: stat /data/geoip: no such file or directory"}
caddy-1 |{"level":"error","ts":1775559071.02553,"logger":"geoip2","msg":"missing geoip database file","editionID":"GeoLite2-City"}
```

This PR ensures that if the database directory is not available or the lock file's parent directory then it will be created automatically.